### PR TITLE
feat: .flake8 파일 수정 (#17)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, W605
+ignore = E203, W503, W605
 max-line-length = 88
 max-complexity = 10
 select = B,C,E,F,W


### PR DESCRIPTION
#17 
1. E266은 주석에 여러개의 #을 못 넣게 하는 규칙
구분선이나 주석의 들여쓰기는 다른 방법으로도 가능하므로 제거

2. E501은 길이 제한 규칙
black에서 88자로 제한하고 있고, black에서 처리하지 못하는 것은 주석에
해당함
작성자가 88자가 넘는 주석이 존재하는 것을 확인하기 위해서는 ignore에
추가해서는 안됨